### PR TITLE
ignore empty text when gen symbol word

### DIFF
--- a/rime-symbols-gen
+++ b/rime-symbols-gen
@@ -272,8 +272,8 @@ def genSymbolWord(file_name):
     text += genTextTypeWord('公顷', '㏊')
     text += genTextTypeWord('马力', '㏋')
     text += genTextTypeWord('英寸', '㏌')
-    text += genTextTypeWord('', '㏍')
-    text += genTextTypeWord('', '㏎')
+    # text += genTextTypeWord('', '㏍')
+    # text += genTextTypeWord('', '㏎')
     text += genTextTypeWord('节', '㏏')
     text += genTextTypeWord('流明', '㏐')
     #text += genTextTypeWord('', '㏑')
@@ -409,4 +409,3 @@ def main():
 
 if __name__ == '__main__':
     exit(main())
-


### PR DESCRIPTION
升级到最新的 squirrel（[0.15版本](https://github.com/rime/squirrel/commit/8ef9442aa0731b61e6a44a7362cbc7c1a01c022e)）后，出现 CPU/内存 打满的情况。

目前定位到是此符号词库中的空字符导致的，看了下代码，作者应该有意识到这个问题，但是有两处空字符漏掉注释了。

https://github.com/fkxxyz/rime-symbols/blob/c34c6a93eb9ce4fec239e2115199f631a6c64763/rime-symbols-gen#L274-L281

详见：
https://github.com/rime/squirrel/issues/499
https://github.com/fkxxyz/rime-cloverpinyin/issues/65