### PR TITLE
remove wrong symbol translation

### DIFF
--- a/rime-symbols-gen
+++ b/rime-symbols-gen
@@ -262,7 +262,7 @@ def genSymbolWord(file_name):
     text += genTextTypeWord('兆欧', '㏁')
     text += genTextTypeWord('上午', '㏂')
     text += genTextTypeWord('贝可', '㏃')
-    text += genTextTypeWord('立方厘米', '㏄')
+    # text += genTextTypeWord('', '㏄')
     text += genTextTypeWord('坎', '㏅')
     text += genTextTypeWord('坎德拉', '㏅')
     text += genTextTypeWord('库伦每千克', '㏆')


### PR DESCRIPTION
背景是最近发现 squirrel 更新到 0.16.1 后，symbols 直接不加载了，经过一系列定位，发现是因为捆绑的 opencc 升级后，不允许有重复。看了一下代码，发现“立方厘米”出现了两次，第二次应该是标注错误了，注释掉这里后就 ok 了。

https://github.com/fkxxyz/rime-symbols/blob/54a4e2fc2ea270d366f2eca3a061c7e00d8170d2/rime-symbols-gen#L233

https://github.com/fkxxyz/rime-symbols/blob/54a4e2fc2ea270d366f2eca3a061c7e00d8170d2/rime-symbols-gen#L265

相关的 issue
- https://github.com/rime/squirrel/issues/703
- https://github.com/rime/squirrel/issues/708