### PR TITLE
Add Action

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,29 @@
+name: Build on Push
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies(OpenCC)
+      run: |
+        pip install OpenCC
+    - name: Run Script
+      run: |
+        python ./rime-symbols-gen
+    - uses: actions/upload-artifact@v4
+      with:
+        name: last-build
+        path: symbol**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 本项目为 opencc 的配置文件，功能是将中文转换为符号，如“平方”转换为 ² ，以此来实现输入法快速输入特殊符号。是为[🍀️四叶草简体拼音](https://github.com/fkxxyz/rime-cloverpinyin)而设计的。
 
+## 最新自动build
+
+<a href="../../actions/">Build</a>
+
 ## 安装
 
 推荐直接使用[🍀️四叶草简体拼音](https://github.com/fkxxyz/rime-cloverpinyin)，自带该功能。


### PR DESCRIPTION
添加actions自动build
=

使用`rime-cloverpinyin v1.1.4`配合`rime win v0.15.0`无法显示符号, 查了一圈issue, 发现代码虽然解决了问题, 但是没有release, 就写了个action来自动build

[fork仓库的测试](https://github.com/LuomingXu/rime-symbols/actions)
